### PR TITLE
More correctly handle errors in aws_request

### DIFF
--- a/aws/plugin.lua
+++ b/aws/plugin.lua
@@ -442,11 +442,18 @@ function aws_request(secret_id, amzTarget, request_body, method)
   if response == nil or err ~= nil then
     return nil, err
   end
-  if response.status ~= 200 then
-    if response.body ~= nil then return json.decode(response.body) end
+
+  -- An error is returned as the response and should be handled
+  if response.status >= 400 then
+    if response.body ~= nil then
+      local err_decoded = json.decode(response.body)
+      -- logging to help identify issues in the plugin going forward.
+      AuditLog.log { message = "__type: "..err_decoded["__type"]..", message: "..err_decoded.message, severity = 'CRITICAL'}
+      return nil, err_decoded
+    end
     return nil, response
   end
-  return json.decode(response.body), err
+  return json.decode(response.body), nil
 end
 
 function get_sso_token(secret_id)


### PR DESCRIPTION
**Background**
While testing this plugin, I noticed it will fail on certain cases. For example, if AWS KMS returns a 400 exception, the plugin will parse the body and return it as if it's a valid response body. This then leads to other functions attempting to index nonexistent fields, crashing the plugin.

**This PR**
Attempts to solve this issue by correctly returning the decoded errors from the KMS and only passing valid responses to the calling function in the plugin; therefore ultimately avoiding the plugin crashing.

I also added an audit log entry so that it could help users detect when an issue is encountered in the plugin. Let me know if you think this addition should be removed. 