### PR TITLE
Fix SSH CA plugin documentation errors

### DIFF
--- a/ssh-ca/plugin.lua
+++ b/ssh-ca/plugin.lua
@@ -88,7 +88,7 @@
 -- 
 -- "`valid_principals`" specifies what username this certificate can be used for.
 -- 
--- "`cert_type`" can be "user" or "server".
+-- "`cert_type`" can be "user" or "host".
 -- 
 -- "`ca_key`" gives the name of the private key that was used when the RSA key was
 -- imported into SDKMS earlier.
@@ -119,7 +119,7 @@
 -- "ca_key":"SSH CA Key",
 -- "extensions":{"permit-pty":""},
 -- "critical_extensions":{"source-address":"10.2.0.0/16,127.0.0.1"},
--- "pubkey":"AAAAB3<more base64 data>"}
+-- "pubkey":"AAAAB3<more base64 data>"
 -- }
 -- ```
 -- 


### PR DESCRIPTION
## Summary
- Correct cert_type value from "server" to "host" in documentation
- Remove extra closing bracket in example JSON that caused invalid syntax

## Details
The code correctly validates "host" as a valid cert_type value (see getCertType function at lines 210-217), but the documentation incorrectly stated "server" at line 91.

The example JSON also had a syntax error with an extra "}" on the pubkey line (line 122), which created invalid JSON.

## Test plan
- [x] Verified cert_type documentation now matches code implementation
- [x] Verified example JSON is now valid syntax